### PR TITLE
ref(services-k8s): remove superflue restartPolicy (defaults)

### DIFF
--- a/services/attachment-storage-service/k8s/deployment/deployment.yaml
+++ b/services/attachment-storage-service/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: attachment-storage-service
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: attachment-storage-service

--- a/services/component-orchestrator/k8s/deployment/deployment.yaml
+++ b/services/component-orchestrator/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: component-orchestrator
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccountName: component-orchestrator-account
       containers:

--- a/services/component-repository/k8s/deployment/deployment.yaml
+++ b/services/component-repository/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: component-repository
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: component-repository

--- a/services/data-hub/k8s/deployment/deployment.yaml
+++ b/services/data-hub/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: data-hub
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: data-hub

--- a/services/logging-service/k8s/deployment/deployment.yaml
+++ b/services/logging-service/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: logging-service
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: logging-service

--- a/services/scheduler/k8s/deployment/deployment.yaml
+++ b/services/scheduler/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: scheduler
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: scheduler

--- a/services/snapshots-service/k8s/deployment/deployment.yaml
+++ b/services/snapshots-service/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: snapshots-service
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
       - name: snapshots-service

--- a/services/webhooks/k8s/deployment/deployment.yaml
+++ b/services/webhooks/k8s/deployment/deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: webhooks
     spec:
-      restartPolicy: Always
       terminationGracePeriodSeconds: 30
       serviceAccountName: component-orchestrator-account
       containers:


### PR DESCRIPTION
##### This targets master after merging https://github.com/openintegrationhub/openintegrationhub/pull/1055

```yaml
      restartPolicy: Always
```

is a [k8s default](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core), so remove it to avoid confusion (as if it was set to _Always_ on purpose):

-- | --
-- | --
restartPolicystring | Restart  policy for all containers within the pod. One of Always, OnFailure,  Never. **Default to Always.** More info:  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy